### PR TITLE
fix: UB due instantiating std::complex with ints

### DIFF
--- a/test/Math.cpp
+++ b/test/Math.cpp
@@ -149,7 +149,7 @@ struct MemberNormable {
     }
 };
 static_assert(ct::utils::norm(MemberNormable{}) == 42);
-static_assert(ct::utils::norm(std::complex{1, 1}) == 2);
+static_assert(ct::utils::norm(std::complex{1.0f, 1.0f}) == 2);
 
 int main()
 {


### PR DESCRIPTION
## What changes

Should fix MSVC warning about instantiating `std::complex` with int's, technically undefined behavior.

## Checklist

- [x] Bug fix (change which fixes issues)
- [ ] New feature (change which introduces functionality)
- [ ] Breaking change (that causes any existing test to change, e.g. API / ABI change)
- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

